### PR TITLE
Improve docs related to release of `v2.0.0`

### DIFF
--- a/docs/pages/dev/updating.md
+++ b/docs/pages/dev/updating.md
@@ -80,7 +80,7 @@ Everything that was previously part of `IESoptLib.jl` is now integrated into `IE
 
 #### Tags
 
-Compontent "tags" are back (or accessible again, they were never gone completely). That means you can tag components to later simplify result handling or working with your model. A tag can be added when creating a component:
+Component "tags" are back (or accessible again, they were never gone completely). That means you can tag components to later simplify result handling or working with your model. A tag can be added when creating a component:
 
 ```{code-block} yaml
 :caption: Adding a tag.

--- a/docs/pages/dev/updating.md
+++ b/docs/pages/dev/updating.md
@@ -19,6 +19,7 @@ See the respective section(s) in the [YAML/Top-level config](../manual/yaml/top_
 - `name`
 - `version`
 - `high_performance`
+- `constraint_safety` is now called `soft_constraints` and part of the `optimization` section.
 
 ### Changes to keyword arguments
 

--- a/docs/pages/dev/updating.md
+++ b/docs/pages/dev/updating.md
@@ -23,8 +23,6 @@ See the respective section(s) in the [YAML/Top-level config](../manual/yaml/top_
 
 ### Changes to keyword arguments
 
-To be written: "parameters" and "config".
-
 Previously we allowed passing arbitrary keyword arguments to public functions, like {py:func}`iesopt.Model.generate` or {py:func}`iesopt.run`. This can lead to problems with latency on previously unseen types of arguments, especially now that we support arbitrary dictionaries as model parameters. This now works differently:
 
 - There are no arbitrary keyword arguments anymore.
@@ -41,9 +39,9 @@ Besides model parameters, specific keyword arguments existed, e.g., `verbosity`.
 import iesopt
 
 iesopt.run("my_config.iesopt.yaml", config = {
-    "general.verbosity.core" = "error",
-    "optimization.snapshots.count" = 168,
-    "files.data_in" = "scenario17/data.csv",
+    "general.verbosity.core": "error",
+    "optimization.snapshots.count": 168,
+    "files.data_in": "scenario17/data.csv",
 })
 ```
 

--- a/docs/pages/dev/updating.md
+++ b/docs/pages/dev/updating.md
@@ -8,11 +8,62 @@ The `2.0.0` release follows the breaking change of `IESopt.jl` going to `v2.0.0`
 
 ### Changes to the top-level config
 
-To be written: everything.
+The structure of the `config` section in the top-level configuration file changed. Overall it's highly similar, but:
+
+- A `general` section was added that properly groups "general" settings, that were previous keyword arguments.
+- Small adjustments were made to account for that.
+- The `results` section changed slightly.
+
+See the respective section(s) in the [YAML/Top-level config](../manual/yaml/top_level.md) documentation. The most important changes relate to the following (sub-)sections:
+
+- `name`
+- `version`
+- `high_performance`
 
 ### Changes to keyword arguments
 
 To be written: "parameters" and "config".
+
+Previously we allowed passing arbitrary keyword arguments to public functions, like {py:func}`iesopt.Model.generate` or {py:func}`iesopt.run`. This can lead to problems with latency on previously unseen types of arguments, especially now that we support arbitrary dictionaries as model parameters. This now works differently:
+
+- There are no arbitrary keyword arguments anymore.
+- Model parameters have to be passed as dictionary, using `parameters = {foo: 1.0, bar: "austria"}`.
+- There is a new and "powerful" `config` keyword argument, explained below.
+
+#### `config`
+
+Besides model parameters, specific keyword arguments existed, e.g., `verbosity`. These are gone and now first-class options in the model's top-level config (see [YAML/Top-level config](../manual/yaml/top_level.md)). With that a way to change them programmatically was in need, which is what the `config` argument does. Take the following example:
+
+```{code-block} python
+:caption: Example usage of `config` keyword argument.
+
+import iesopt
+
+iesopt.run("my_config.iesopt.yaml", config = {
+    "general.verbosity.core" = "error",
+    "optimization.snapshots.count" = 168,
+    "files.data_in" = "scenario17/data.csv",
+})
+```
+
+The passed dictionary modifies the top-level configuration during the parsing step. That means you are able to overwrite / set each configuration option programmatically. The access pattern follows the structure of the `config` section in the top-level configuration file. For example, the verbosity in the YAML looks like:
+
+```{code-block} yaml
+:caption: Verbosity example in the top-level YAML.
+
+config:
+  general:
+    verbosity:
+      core: info
+```
+
+To modify / set this, `general.verbosity.core` is used. As you can see that opens the possibility to modify, e.g., files that are loaded based on (for example) which scenario we are in by modifying the `files` section, using `files.data_in`. Here `data_in` is the "name" used in the model later on (using `some_col@data_in`).
+
+Further, this means you no longer need to use "model parameters" for stuff that is actually part of the `config` section, e.g., the number of Snapshots in your model. Instead of coming up with a parameter, e.g., `my_snapshot_count`, using it as `count: <my_snapshot_count>`, and then passing it as `iesopt.run("...", my_snapshot_count = 168)`, you can now just modify that as shown above by setting it using the accessor `optimization.snapshots.count`.
+
+#### `parameters`
+
+Any dictionary passed to this will be used in the same way as keyword arguments were used before: Parameters given there are replaced in the `parameters` section (which might be based on an external `*.iesopt.param.yaml` file).
 
 ### Changes to result extraction
 
@@ -30,4 +81,47 @@ Everything that was previously part of `IESoptLib.jl` is now integrated into `IE
 
 #### Tags
 
-To be written.
+Compontent "tags" are back (or accessible again, they were never gone completely). That means you can tag components to later simplify result handling or working with your model. A tag can be added when creating a component:
+
+```{code-block} yaml
+:caption: Adding a tag.
+
+components:
+  my_unit:
+    type: Unit
+    tags: CustomUnit
+```
+
+The attribute `tags` supports single tags (e.g., `CustomUnit`) or lists of tags (e.g., `[CustomUnit]` or `[CustomUnit, FindMe]`).
+
+:::{tip}
+Each core component automatically tags its own type, so each `Unit` will already be tagged with the tag `"Unit"`.
+
+Most importantly, that means you are also able to extract all `Virtual`s (non-existing components related to templates that you use), since each of these also tags its "actual type".
+:::
+
+Using this is possible with {py:func}`iesopt.Model.get_components`:
+
+```{code-block} python
+:caption: Extracting tagged components.
+
+import iesopt
+
+model = iesopt.run("tagged_model.iesopt.config")
+
+my_units = model.get_components("CustomUnit")
+```
+
+When passing a `list` of tags, only components having ALL of these tags are returned.
+
+:::{tip}
+Most importantly, that (and the fact that components "auto-tag" their type) means you are also able to extract all `Virtual`s (non-existing components related to templates that you use), since each of these also tags its "actual type". Consider a template `Battery` that you use to initialize a battery
+
+```yaml
+components:
+  my_bat:
+    type: Battery
+```
+
+All batteries can then be found using `model.get_components("Battery")`. This can also be really helpful in addons, where (using Julia) you can find, e.g., all CHPs in your model by doing `chps = IESopt.get_components(model, "CHP")`.
+:::

--- a/src/iesopt/julia/util.py
+++ b/src/iesopt/julia/util.py
@@ -61,11 +61,11 @@ def jl_docs(obj: str, module: str = "IESopt"):
 
 
 def recursive_convert_py2jl(item):
-    juliacall = get_iesopt_module_attr("juliacall")
-
     if isinstance(item, dict):
+        juliacall = get_iesopt_module_attr("juliacall")
         return juliacall.Main.Dict({k: recursive_convert_py2jl(v) for (k, v) in item.items()})
     if isinstance(item, list):
+        juliacall = get_iesopt_module_attr("juliacall")
         return juliacall.convert(juliacall.Main.Vector, [recursive_convert_py2jl(v) for v in item])
 
     return item

--- a/src/iesopt/model.py
+++ b/src/iesopt/model.py
@@ -181,6 +181,18 @@ class Model:
             return self._IESopt.get_component(self.core, component)
         except Exception:
             raise Exception(f"Error while retrieving component `{component}` from model")
+    
+    def get_components(self, tagged = None):
+        """
+        Get all components of the model, possibly filtered by (a) tag(s).
+        
+        Arguments:
+            tagged (str or list of str): The tag(s) to filter the components by, can be `None` (default) to get all components.
+        """
+        if tagged is None:
+            return self._IESopt.get_components(self.core)
+        
+        return self._IESopt.get_components(self.core, recursive_convert_py2jl(tagged))
 
     def get_variable(self, component: str, variable: str):
         """Get a specific variable from a core component."""

--- a/src/iesopt/model.py
+++ b/src/iesopt/model.py
@@ -181,17 +181,17 @@ class Model:
             return self._IESopt.get_component(self.core, component)
         except Exception:
             raise Exception(f"Error while retrieving component `{component}` from model")
-    
-    def get_components(self, tagged = None):
+
+    def get_components(self, tagged=None):
         """
         Get all components of the model, possibly filtered by (a) tag(s).
-        
+
         Arguments:
             tagged (str or list of str): The tag(s) to filter the components by, can be `None` (default) to get all components.
         """
         if tagged is None:
             return self._IESopt.get_components(self.core)
-        
+
         return self._IESopt.get_components(self.core, recursive_convert_py2jl(tagged))
 
     def get_variable(self, component: str, variable: str):


### PR DESCRIPTION
This pull request includes updates to the documentation and codebase for the `IESopt` library, focusing on the configuration structure, keyword arguments, and component tagging. The most important changes are outlined below:

### Documentation Updates:

* [`docs/pages/dev/updating.md`](diffhunk://#diff-eda70705e375b4fe84b4ab08380a8fdaab9acbdba62047e54b6cc045e14f1586L11-R65): Updated the top-level configuration structure, including the addition of a `general` section, renaming `constraint_safety` to `soft_constraints`, and removing arbitrary keyword arguments in favor of a `config` keyword argument.
* [`docs/pages/manual/yaml/top_level.md`](diffhunk://#diff-03b2d527bf206b4720776f9c5ff4c9371bd1d5f84532f4828f968825f6d361e0R85): Detailed the new `general` section, including subsections for `version`, `name`, and `verbosity`. Added documentation for the `soft_constraints` section under `optimization`. [[1]](diffhunk://#diff-03b2d527bf206b4720776f9c5ff4c9371bd1d5f84532f4828f968825f6d361e0R85) [[2]](diffhunk://#diff-03b2d527bf206b4720776f9c5ff4c9371bd1d5f84532f4828f968825f6d361e0L108-R121) [[3]](diffhunk://#diff-03b2d527bf206b4720776f9c5ff4c9371bd1d5f84532f4828f968825f6d361e0L136-R142) [[4]](diffhunk://#diff-03b2d527bf206b4720776f9c5ff4c9371bd1d5f84532f4828f968825f6d361e0R164) [[5]](diffhunk://#diff-03b2d527bf206b4720776f9c5ff4c9371bd1d5f84532f4828f968825f6d361e0R191-R200) [[6]](diffhunk://#diff-03b2d527bf206b4720776f9c5ff4c9371bd1d5f84532f4828f968825f6d361e0R275-R276) [[7]](diffhunk://#diff-03b2d527bf206b4720776f9c5ff4c9371bd1d5f84532f4828f968825f6d361e0R297-R298) [[8]](diffhunk://#diff-03b2d527bf206b4720776f9c5ff4c9371bd1d5f84532f4828f968825f6d361e0R310-R327) [[9]](diffhunk://#diff-03b2d527bf206b4720776f9c5ff4c9371bd1d5f84532f4828f968825f6d361e0L311-R351)

### Codebase Updates:

* [`src/iesopt/julia/util.py`](diffhunk://#diff-eb132c5037eb6ab8672ddd350667f0cd3d0153b8636d00e52ffed2cf863ea5b5L64-R68): Refactored `recursive_convert_py2jl` to move the `juliacall` import inside the function for better efficiency.
* [`src/iesopt/model.py`](diffhunk://#diff-306ea50a74855408b8efc54b091b4b78b04cdd959d33bd40b950099ac50aa08aR185-R196): Added a new method `get_components` to retrieve components by tags, enhancing the model's component handling capabilities.