### PR TITLE
Add Ipopt to the list of solvers that can be automatically looked up

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "iesopt"
-version = "2.1.0"
+version = "2.2.0"
 description = "IESopt -- an Integrated Energy System Optimization framework."
 keywords = ["integrated energy systems", "optimization", "energy model", "modelling"]
 authors = [

--- a/src/iesopt/julia/setup.py
+++ b/src/iesopt/julia/setup.py
@@ -15,6 +15,7 @@ def lookup_package(name: str):
         "iesopt": ("IESopt", "ed3f0a38-8ad9-4cf8-877e-929e8d190fe9"),
         "gurobi": ("Gurobi", "2e9cd046-0924-5485-92f1-d5272153d98b"),
         "cplex": ("CPLEX", "a076750e-1247-5638-91d2-ce28b192dca0"),
+        "ipopt": ("Ipopt", "b6b21f68-93f8-5de0-b562-5493be1d77c9"),
     }
 
     if name in lookup:


### PR DESCRIPTION
This pull request includes changes to update the version of the `iesopt` package and add a new package to the lookup function.

Version update:

* [`pyproject.toml`](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711L7-R7): Updated the version of the `iesopt` package from `2.1.0` to `2.2.0`.

Package addition:

* [`src/iesopt/julia/setup.py`](diffhunk://#diff-5cf1212ef953b85b26aa0a1d19ba3782ea75b479f52187300e7fae91479df723R18): Added the `ipopt` package to the `lookup` dictionary in the `lookup_package` function.