### PR TITLE
chore: bump core version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "iesopt"
-version = "2.3.0"
+version = "2.4.0"
 description = "IESopt -- an Integrated Energy System Optimization framework."
 keywords = ["integrated energy systems", "optimization", "energy model", "modelling"]
 authors = [

--- a/src/iesopt/config.py
+++ b/src/iesopt/config.py
@@ -13,7 +13,7 @@ def _strtobool(val: str):
 class Config:
     DEFAULTS = {
         "IESOPT_JULIA": "1.11.2",
-        "IESOPT_CORE": "2.3.0",
+        "IESOPT_CORE": "2.4.0",
         "IESOPT_JUMP": "1.23.6",
         "IESOPT_SOLVER_HIGHS": "1.13.0",
         "IESOPT_MULTITHREADED": "no",  # yes, no


### PR DESCRIPTION
This pull request includes version updates for the `iesopt` package. The most important changes are:

Version updates:

* [`pyproject.toml`](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711L7-R7): Updated the version of the `iesopt` package from `2.3.0` to `2.4.0`.
* [`src/iesopt/config.py`](diffhunk://#diff-8f4214c07bc046e1279c442088d16a616b189d3ae66307da75e46eb4a660f434L16-R16): Updated the `IESOPT_CORE` default version from `2.3.0` to `2.4.0`.