### PR TITLE
Workaround various SSL related issues using `JULIA_SSL_CA_ROOTS_PATH`

### DIFF
--- a/src/iesopt/julia/setup.py
+++ b/src/iesopt/julia/setup.py
@@ -64,6 +64,14 @@ def setup_julia():
     # ssl._create_default_https_context = ssl._create_unverified_context
     # logger.warn("Disabling SSL verification to prevent problems; this may be unsafe")
 
+    # Set `JULIA_SSL_CA_ROOTS_PATH` to prevent various SSL related issues (with Julia setup; LibGit2; etc.).
+    if "JULIA_SSL_CA_ROOTS_PATH" in os.environ:
+        logger.warn(
+            "Overwriting the env. variable `JULIA_SSL_CA_ROOTS_PATH` (current: `%s`) to prevent SSL issues during the Julia setup"
+            % str(os.environ["JULIA_SSL_CA_ROOTS_PATH"])
+        )
+    os.environ["JULIA_SSL_CA_ROOTS_PATH"] = ""
+
     # Setup Julia (checking if it "looks" valid).
     import juliapkg
 


### PR DESCRIPTION
This pull request includes a change to the `setup_julia` function in the `src/iesopt/julia/setup.py` file to address SSL-related issues during Julia setup. 

Improvements to SSL handling:

* [`src/iesopt/julia/setup.py`](diffhunk://#diff-5cf1212ef953b85b26aa0a1d19ba3782ea75b479f52187300e7fae91479df723R67-R74): Added code to set the `JULIA_SSL_CA_ROOTS_PATH` environment variable to prevent various SSL-related issues. It includes a warning if the environment variable is being overwritten.