### PR TITLE
Fix `kwarg` conversion in Python to Julia conversion

### DIFF
--- a/src/iesopt/julia/util.py
+++ b/src/iesopt/julia/util.py
@@ -69,11 +69,11 @@ def recursive_convert_py2jl(item):
     if isinstance(item, dict):
         julia = get_iesopt_module_attr("julia")
         convert = get_iesopt_module_attr("juliacall").convert
-        return convert(julia.Dict, {k: recursive_convert_py2jl(v) for (k, v) in item.items()})
+        return convert(julia.seval("Dict{String, Any}"), {k: recursive_convert_py2jl(v) for (k, v) in item.items()})
     elif isinstance(item, list):
         julia = get_iesopt_module_attr("julia")
         convert = get_iesopt_module_attr("juliacall").convert
-        return convert(julia.Vector, [recursive_convert_py2jl(v) for v in item])
+        return convert(julia.seval("Vector{Any}"), [recursive_convert_py2jl(v) for v in item])
     elif isinstance(item, pd.DataFrame):
         julia = get_iesopt_module_attr("julia")
         return julia.IESopt.DataFrames.DataFrame(item)

--- a/tests/test_python_julia_conversion.py
+++ b/tests/test_python_julia_conversion.py
@@ -1,0 +1,16 @@
+import iesopt
+
+
+class TestPythonJuliaConversion:
+    def test_kwargs_dict(self, tmp_path):
+        # Refer to: https://github.com/ait-energy/IESopt.jl/issues/66
+
+        configs = [
+            {"a": 1, "b": 2.0, "c": "string"},
+            {"a": 1, "c": "string"} | {"b": 2.0},
+            {"b": 2.0} | {"a": 1, "c": "string"},
+        ]
+
+        for config in configs:
+            model = iesopt.Model("", config=config)
+            assert type(model._kwargs["config"]["a"]) is int

--- a/uv.lock
+++ b/uv.lock
@@ -482,7 +482,7 @@ wheels = [
 
 [[package]]
 name = "iesopt"
-version = "2.5.1.dev0"
+version = "2.6.1.dev0"
 source = { editable = "." }
 dependencies = [
     { name = "juliacall" },


### PR DESCRIPTION
This fixes https://github.com/ait-energy/IESopt.jl/issues/66

---

This pull request includes updates to the `recursive_convert_py2jl` function in `src/iesopt/julia/util.py` and adds new tests for Python to Julia conversion in `tests/test_python_julia_conversion.py`. The most important changes are listed below:

### Functionality Improvements:

* [`src/iesopt/julia/util.py`](diffhunk://#diff-eb132c5037eb6ab8672ddd350667f0cd3d0153b8636d00e52ffed2cf863ea5b5L72-R76): Updated the `recursive_convert_py2jl` function to use `julia.seval` for specifying Julia types (`Dict{String, Any}` and `Vector{Any}`) instead of directly using `julia.Dict` and `julia.Vector`. This ensures more precise type conversion when handling dictionaries and lists.

### Testing Enhancements:

* [`tests/test_python_julia_conversion.py`](diffhunk://#diff-542cc7da9c852f1dda70cf0e422b189691f322540886b64f7511212edc3e7159R1-R16): Added a new test class `TestPythonJuliaConversion` with a test method `test_kwargs_dict` to verify the correct conversion of Python dictionaries to Julia dictionaries, ensuring that the types of the converted values are as expected. This includes testing different configurations of dictionary merging.