### PR TITLE
fix: load results from jld2 files

### DIFF
--- a/src/iesopt/results.py
+++ b/src/iesopt/results.py
@@ -389,7 +389,7 @@ class Results:
         return Results._safe_convert(result)
 
     def _from_file(self, file: str):
-        results = self._IESopt.load_results(file)
+        results = self._IESopt.ResultsJLD2.load_results(file)
 
         result_entries = ddict({})
         for key in results.keys():


### PR DESCRIPTION
Not sure if this is the intended way, but I hope this would fix the following error:

```python
>>> results = iesopt.Results(file="opt/test/out/my_model/my_scenario.iesopt.result.jld2")
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "C:\Users\SchwabenederD\Code\Projects\Restwasser\.venv\Lib\site-packages\pydantic\_internal\_validate_call.py", line 38, in wrapper_function
    return wrapper(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\Users\SchwabenederD\Code\Projects\Restwasser\.venv\Lib\site-packages\pydantic\_internal\_validate_call.py", line 111, in __call__
    res = self.__pydantic_validator__.validate_python(pydantic_core.ArgsKwargs(args, kwargs))
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\Users\SchwabenederD\Code\Projects\Restwasser\.venv\Lib\site-packages\iesopt\results.py", line 89, in __init__
    self._from_file(file)
  File "C:\Users\SchwabenederD\Code\Projects\Restwasser\.venv\Lib\site-packages\iesopt\results.py", line 392, in _from_file
    results = self._IESopt.load_results(file)
              ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\Users\SchwabenederD\.julia\packages\PythonCall\WMWY0\src\JlWrap\any.jl", line 249, in __getattr__
    return self._jl_callmethod($(pyjl_methodnum(pyjlany_getattr)), k)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^
AttributeError: Julia: UndefVarError: `load_results` not defined in `IESopt`
```