### PR TITLE
Document snapshot offset and offset_virtual_files

### DIFF
--- a/docs/pages/manual/yaml/top_level.md
+++ b/docs/pages/manual/yaml/top_level.md
@@ -269,15 +269,18 @@ Here we define the Snapshots (IESopt's representation of time steps, including a
 :`count` (`int`): The number of Snapshots to use in the optimization.
 :`names` (`str`, optional): Linked column of a loaded file (using the usual `col@file` syntax) that contains the names of the Snapshots. These are purely for aesthetic purposes (e.g., result data frames) and are not used in the optimization.
 :`weights` (`float`, default = `1`): The duration of each Snapshot in hours. Values below `1` are interpreted as fractions of an hour, e.g., `0.25` for 15 minutes.
+:`offset` (`int`, default = `0`): The offset at where to start reading a time series passed to the model. `168` means that the first 168 entries (rows) will be skipped and the first Snapshot is based on the 169th row.
+:`offset_virtual_files` (`bool`): Mandatory if `offset > 0`, without effect otherwise. If `true` time series passed using the `virtual_files` keyword argument will respect the `offset`, otherwise they are considered to "be already offset" and will be used directly from the first row on.
 
 ```{code-block} yaml
-:caption: Example for the `snapshots` section.
+:caption: Example for the `snapshots` section, with non-1-hourly resolution.
 
 config:
   optimization:
     snapshots:
-      count: 24
-      weights: 4
+      count: 24   # total of four days modeling period
+      weights: 4  # four hours per Snapshot
+      offset: 6   # start at the second day
 ```
 
 #### `objectives`


### PR DESCRIPTION
This pull request introduces updates to the documentation in `docs/pages/manual/yaml/top_level.md` to clarify and expand the configuration options for the `snapshots` section. The changes primarily add new parameters and improve the example provided for non-1-hourly resolution.

### Updates to the `snapshots` section:

* Added a new parameter `offset` to specify the starting point for reading a time series passed to the model. This allows skipping a defined number of rows before starting the optimization. (`[docs/pages/manual/yaml/top_level.mdR272-R283](diffhunk://#diff-03b2d527bf206b4720776f9c5ff4c9371bd1d5f84532f4828f968825f6d361e0R272-R283)`)
* Introduced the `offset_virtual_files` parameter, which is mandatory when `offset > 0`. It determines whether virtual files respect the `offset` or are used directly from the first row. (`[docs/pages/manual/yaml/top_level.mdR272-R283](diffhunk://#diff-03b2d527bf206b4720776f9c5ff4c9371bd1d5f84532f4828f968825f6d361e0R272-R283)`)

### Example enhancement:

* Updated the example under the `snapshots` section to demonstrate modeling with non-1-hourly resolution, including the use of the `offset` parameter for starting at a specific point in a time series. (`[docs/pages/manual/yaml/top_level.mdR272-R283](diffhunk://#diff-03b2d527bf206b4720776f9c5ff4c9371bd1d5f84532f4828f968825f6d361e0R272-R283)`)