### PR TITLE
QoL for running models on an old SLURM cluster

### DIFF
--- a/src/iesopt/julia/setup.py
+++ b/src/iesopt/julia/setup.py
@@ -159,7 +159,7 @@ def setup_julia(target: Path, sysimage: Path):
             logger.warning(
                 " It seems we are running on a cluster; if you encounter an error related to 'GLIBCXX_*.*.*, "
                 + "or 'Unable to load dependent library', please manually set the LD_LIBRARY_PATH environment "
-                + "variable (e.g., by using 'export LD_LIBRARY_PATH=...')to: '%s'." % libdir
+                + "variable (e.g., by using 'export LD_LIBRARY_PATH=\"...\"')to: '%s'." % libdir
             )
 
     os.environ["PYTHON_JULIACALL_BINDIR"] = str(Path(juliapkg.executable()).parent)


### PR DESCRIPTION
This pull request adds logic to detect when the code is running on a Linux-based cluster environment and provides a warning about potential GLIBC-related issues. If such an environment is detected, the user is advised to set the `LD_LIBRARY_PATH` environment variable to help avoid library loading errors.

Cluster environment detection and warning:

* In `setup_julia` (`src/iesopt/julia/setup.py`), added a check for cluster-related hostnames on Linux systems and a warning message with instructions to set `LD_LIBRARY_PATH` if GLIBC or library loading errors occur.