### PR TITLE
Use tempdir for juliapkg.json to prevent issues on parallel cluster runs

### DIFF
--- a/src/iesopt/__init__.py
+++ b/src/iesopt/__init__.py
@@ -1,15 +1,27 @@
 import os
 import importlib.metadata
 from pathlib import Path
+import tempfile
 
 # Set version.
 __version__ = importlib.metadata.version("iesopt")
 
 # Set juliapkg target path.
-__target__ = Path().cwd() / ".iesopt"
+__target__ = Path(tempfile.mkdtemp(prefix="iesopt"))
+__target__.mkdir(exist_ok=True)
+try:
+    _pre_295_target = (Path().cwd() / ".iesopt" / "juliapkg.json").resolve()
+    if _pre_295_target.exists():
+        print(
+            "WARNING: Found an old `juliapkg.json` file from previous version of `iesopt`, removing it to prevent potential"
+            " conflicts; you should only see this warning once after upgrading"
+        )
+        _pre_295_target.unlink()
+except Exception as e:
+    print(f"WARNING: Failed to remove old `juliapkg.json` file: {e}")
 
 # Set sysimage path.
-__sysimage__ = __target__ / ("sysimage_v" + __version__.replace(".", "-") + ".so")
+__sysimage__ = Path().cwd() / ".iesopt" / ("sysimage_v" + __version__.replace(".", "-") + ".so")
 
 # =======================================================================
 # Setup "module globals" that will be overwritten internally.


### PR DESCRIPTION
This pull request updates the initialization logic in `src/iesopt/__init__.py` to improve how temporary directories and legacy files are handled. The main changes focus on using a temporary directory for package targets, cleaning up old configuration files, and clarifying the path for the sysimage.

Directory and file management improvements:

* Changed `__target__` to use a temporary directory (via `tempfile.mkdtemp`) instead of a fixed `.iesopt` directory in the current working directory. This helps avoid conflicts and ensures cleaner temporary storage.
* Added logic to detect and remove an old `juliapkg.json` file from previous versions, printing a warning if found or if removal fails. This helps prevent potential conflicts after upgrading.

Path handling update:

* Updated `__sysimage__` to always point to the `.iesopt` directory in the current working directory, regardless of the new temporary target directory logic.